### PR TITLE
Add : JS cookie support for auth

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@ import (
 
 // Client for the Confluence API
 type Client struct {
+	Cookie   string
 	Username string
 	Password string
 	Endpoint string
@@ -45,7 +46,11 @@ func (client *Client) request(method string, apiEndpoint string, queryParams str
 	req.Header["X-Atlassian-Token"] = []string{"no-check"}
 	req.Header["Content-Type"] = []string{"application/json"}
 
-	req.SetBasicAuth(client.Username, client.Password)
+	if client.Cookie != "" {
+		req.Header.Add("JSESSIONID", client.Cookie)
+	} else {
+		req.SetBasicAuth(client.Username, client.Password)
+	}
 
 	res, _ := http.DefaultClient.Do(req)
 

--- a/client.go
+++ b/client.go
@@ -46,9 +46,8 @@ func (client *Client) request(method string, apiEndpoint string, queryParams str
 	req.Header["X-Atlassian-Token"] = []string{"no-check"}
 	req.Header["Content-Type"] = []string{"application/json"}
 
-	fmt.Println("cookie : ", client.Cookie)
 	if client.Cookie != "" {
-		req.Header.Set("Cookie", fmt.Sprintf("JSESSIONID=%v;", client.Cookie))
+		req.Header.Set("Cookie", fmt.Sprintf("JSESSIONID=%v", client.Cookie))
 	} else {
 		req.SetBasicAuth(client.Username, client.Password)
 	}

--- a/client.go
+++ b/client.go
@@ -47,7 +47,7 @@ func (client *Client) request(method string, apiEndpoint string, queryParams str
 	req.Header["Content-Type"] = []string{"application/json"}
 
 	if client.Cookie != "" {
-		req.Header.Add("JSESSIONID", client.Cookie)
+		req.Header.Add("Cookie", fmt.Sprintf("JSESSIONID=%v", client.Cookie))
 	} else {
 		req.SetBasicAuth(client.Username, client.Password)
 	}

--- a/client.go
+++ b/client.go
@@ -46,8 +46,9 @@ func (client *Client) request(method string, apiEndpoint string, queryParams str
 	req.Header["X-Atlassian-Token"] = []string{"no-check"}
 	req.Header["Content-Type"] = []string{"application/json"}
 
+	fmt.Println("cookie : ", client.Cookie)
 	if client.Cookie != "" {
-		req.Header.Add("Cookie", fmt.Sprintf("JSESSIONID=%v", client.Cookie))
+		req.Header.Set("Cookie", fmt.Sprintf("JSESSIONID=%v;", client.Cookie))
 	} else {
 		req.SetBasicAuth(client.Username, client.Password)
 	}


### PR DESCRIPTION
our self hosted instance of Confluence is using SAML for login and by so basic auth, and tokens are not supported.

trying to use a cookie for REST API auth, which should be working from what is documented here:
https://developer.atlassian.com/server/jira/platform/cookie-based-authentication/
